### PR TITLE
style(cpp): brace macro-invocation loop bodies

### DIFF
--- a/ttt-mt.cc
+++ b/ttt-mt.cc
@@ -251,7 +251,9 @@ static Result play(Board &circle, Board &cross, const uint16_t *__restrict pos,
     for (int k = 0; k < BOARD_SIZE_SQUARED; k += CHUNK)
     {
         for (int c = 0; c < CHUNK; c++)
+        {
             SHUFFLE_STEP(rng, m, out, pt);
+        }
 
         for (int c = 0; c < CHUNK; c += 2)
         {
@@ -269,7 +271,9 @@ static Result play(Board &circle, Board &cross, const uint16_t *__restrict pos,
     }
 done:
     while (m <= BOARD_SIZE_SQUARED)
+    {
         SHUFFLE_STEP(rng, m, out, pt);
+    }
 
     return r;
 }
@@ -291,7 +295,9 @@ static void worker(int lo, int hi, const uint32_t *seeds, Counts *out_counts)
         uint64_t rng = seeds[lo];
         int m = 1;
         while (m <= BOARD_SIZE_SQUARED)
+        {
             SHUFFLE_STEP(rng, m, perm[0], POS.v);
+        }
     }
 
     for (int g = lo; g < hi; g++)

--- a/ttt.cc
+++ b/ttt.cc
@@ -24,7 +24,6 @@
  * For more information, please refer to <https://unlicense.org/>
  */
 
-
 #include <chrono>
 #include <cstdint>
 #include <cstring>
@@ -178,7 +177,9 @@ Result play(const uint16_t *__restrict pos, uint16_t *__restrict out)
     for (int k = 0; k < BOARD_SIZE_SQUARED; k += CHUNK)
     {
         for (int c = 0; c < CHUNK; c++)
+        {
             SHUFFLE_STEP(rng, m, out, pt);
+        }
 
         for (int c = 0; c < CHUNK; c += 2)
         {
@@ -197,7 +198,9 @@ Result play(const uint16_t *__restrict pos, uint16_t *__restrict out)
 done:
     // A game that ended early still owes the rest of the permutation.
     while (m <= BOARD_SIZE_SQUARED)
+    {
         SHUFFLE_STEP(rng, m, out, pt);
+    }
 
     rng_state = rng;
     return r;
@@ -217,7 +220,9 @@ int main()
         uint64_t rng = rng_state;
         int m = 1;
         while (m <= BOARD_SIZE_SQUARED)
+        {
             SHUFFLE_STEP(rng, m, perm[0], POS.v);
+        }
         rng_state = rng;
     }
 


### PR DESCRIPTION
Stacked on top of differental/ttt_test#4 — based on that PR's head (`main` @ `3846538`), so this diff is only the review fixes.

Addresses all three inline comments from @differental on #4:

- **`ttt.cc:27` "Unnecessary newline"** — debris from the removed `#include <array>`. Dropped.
- **`ttt.cc:181` "Please put brackets around this"** — braced.
- **`ttt.cc:200` "Brackets {}"** — braced.

`SHUFFLE_STEP` is a `do { ... } while (0)` macro, so the bare bodies were not a latent bug, but that is not visible at the call site, which is the reason to brace them.

Applied the same rule to three unflagged copies of the identical construct: `ttt.cc:220` (the priming block in `main`), and `ttt-mt.cc:254`, `:272`, `:294`. Left the braceless single-statement `if` bodies and the nested `for` alone, since upstream `ttt.cc` already uses that style and the comments were specific to macro-invocation loop bodies.

Braces only, no semantic change. Both files pass `g++ -fsyntax-only -Wall -Wextra` clean.
